### PR TITLE
Remove instructional text from CTA section

### DIFF
--- a/src/components/CTAAndFooter.js
+++ b/src/components/CTAAndFooter.js
@@ -67,17 +67,7 @@ const CTASubtitle = styled(motion.p)`
 const CTAButtonContainer = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
-`;
-
-const CTAText = styled(motion.span)`
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: #1e3a8a;
-
-  @media (max-width: 768px) {
-    font-size: 1rem;
-  }
+  justify-content: center;
 `;
 
 const CTAButton = styled(motion.a)`
@@ -280,14 +270,6 @@ const CTAAndFooter = () => {
           </CTAContent>
 
           <CTAButtonContainer>
-            <CTAText
-              initial={{ opacity: 0, x: 30 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.6, delay: 0.4 }}
-            >
-              Hit the connect button
-            </CTAText>
             <CTAButton
               onClick={handleCTAClick}
               initial={{ opacity: 0, scale: 0.5 }}


### PR DESCRIPTION
# Remove instructional text from CTA section

## 📝 Description

This PR simplifies the Call-to-Action (CTA) section by removing the "Hit the connect button" instructional text while preserving the main CTA button functionality and styling.

## 🎯 Changes Made

- **Removed** `CTAText` styled component and related imports
- **Removed** "Hit the connect button" text element from CTA section
- **Simplified** `CTAButtonContainer` layout to center the button
- **Maintained** all existing button functionality and animations
- **Preserved** responsive design and hover effects

## 🖼️ Visual Impact

**Before:**
- CTA section displayed: Title + Subtitle + "Hit the connect button" text + Arrow button

**After:**
- CTA section displays: Title + Subtitle + Arrow button (centered)

## 🧪 Testing

- [x] CTA button remains clickable and opens Calendly link
- [x] Button animations and hover effects work correctly
- [x] Responsive design maintained across all breakpoints
- [x] No console errors or warnings
- [x] Layout centers properly without the text element

## 📱 Responsive Behavior

- Desktop: Button centered in the right section
- Tablet/Mobile: Button centered below the title content

## 🔗 Related

- Addresses UI cleanup requirements
- Improves visual focus on the primary CTA button
- Reduces visual clutter in the hero section

## 📋 Checklist

- [x] Code follows project style guidelines
- [x] Responsive design tested on multiple screen sizes
- [x] No breaking changes to existing functionality
- [x] All animations and interactions preserved
- [x] Cross-browser compatibility maintained